### PR TITLE
Fixing wrong URL's on Developers page (both IT and EN)

### DIFF
--- a/public/developers.html
+++ b/public/developers.html
@@ -294,7 +294,7 @@
 											data-ca-options='{ "triggerHandler": "inview", "animationTarget": "all-childs", "duration": 800, "startDelay": 1000, "delay": 120, "initValues": { "translateY": 50, "opacity": 0 }, "animations": { "translateY": 0, "opacity": 1 } }'>
 											Il set completo di manuali, guide e tutorial che fornisce tutta la
 											documentazione completa dell'ecosistema Scrypta.</p>
-										<a href="https://github.com/scryptachain/scrypta-dapp-starter" target="_blank"
+										<a href="https://scrypta.wiki/" target="_blank"
 											class="btn btn-underlined text-uppercase font-size-12 font-weight-bold ltr-sp-2 color-secondary text-hover-white">
 											<span>
 												<span class="btn-txt">Documentazione</span>
@@ -373,7 +373,7 @@
 											</span>
 										</a>
 										<br>
-										<a href="https://it.scrypta.wiki/core/"
+										<a href="https://scrypta.wiki/it/#/core/inizio"
 											target="_blank"
 											class="btn btn-underlined text-uppercase font-size-12 font-weight-bold ltr-sp-2 color-secondary text-hover-white">
 											<span>
@@ -450,7 +450,7 @@
 												<span class="btn-txt">Repository</span>
 											</span>
 										</a>
-										<a href="https://it.scrypta.wiki/idanode/" target="_blank"
+										<a href="https://scrypta.wiki/it/#/idanode/inizio" target="_blank"
 											class="btn btn-underlined text-uppercase font-size-12 font-weight-bold ltr-sp-2 color-secondary text-hover-white">
 											<span>
 												<span class="btn-txt">Documentazione</span>

--- a/public/en/developers.html
+++ b/public/en/developers.html
@@ -294,7 +294,7 @@
 											data-ca-options='{ "triggerHandler": "inview", "animationTarget": "all-childs", "duration": 800, "startDelay": 1000, "delay": 120, "initValues": { "translateY": 50, "opacity": 0 }, "animations": { "translateY": 0, "opacity": 1 } }'>
 											The complete set of manuals, guides and tutorials that provides a depth
 											documentation for the Scrypta ecosystem.</p>
-										<a href="https://github.com/scryptachain/scrypta-dapp-starter" target="_blank"
+										<a href="https://scrypta.wiki/" target="_blank"
 											class="btn btn-underlined text-uppercase font-size-12 font-weight-bold ltr-sp-2 color-secondary text-hover-white">
 											<span>
 												<span class="btn-txt">Documentation</span>
@@ -375,7 +375,7 @@
 											</span>
 										</a>
 										<br>
-										<a href="https://en.scrypta.wiki/core/"
+										<a href="https://scrypta.wiki/en/#/core/start"
 											target="_blank"
 											class="btn btn-underlined text-uppercase font-size-12 font-weight-bold ltr-sp-2 color-secondary text-hover-white">
 											<span>
@@ -452,7 +452,7 @@
 												<span class="btn-txt">Repository</span>
 											</span>
 										</a>
-										<a href="https://en.scrypta.wiki/idanode/" target="_blank"
+										<a href="https://scrypta.wiki/en/#/idanode/start" target="_blank"
 											class="btn btn-underlined text-uppercase font-size-12 font-weight-bold ltr-sp-2 color-secondary text-hover-white">
 											<span>
 												<span class="btn-txt">Documentation</span>


### PR DESCRIPTION
1. Scrypta Core Documentation link for both Italian and English wiki was leading to a 404 page.
2. Scrypta IdA node Documentation link for both Italian and English wiki was leading to a 404 page too.
3. On the first section of the /developers page, Scrypta Wiki, the Documentation link was leading to [scrypta-vue-dapp-starter](https://github.com/scryptachain/scrypta-vue-dapp-starter ) on GitHub, changed to be the wiki official page 